### PR TITLE
Adding ipykernel to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ spacy==3.0.6
 spacy-transformers==1.0.2
 flair==0.8
 tensorflow==2.5.0
+ipykernel==5.5.5


### PR DESCRIPTION
Adding ipykernel to the requirements file enables `python -m ipykernel install --user --name ml --display-name "ML"` to run without errors. Otherwise, I get the `no module named ipykernel` error